### PR TITLE
use hook friendly sc version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
 
                 //Styled components
                 implementation("org.jetbrains:kotlin-styled:1.0.0-pre.110-kotlin-1.4.0")
-                implementation(npm("styled-components", "~5.1.1"))
+                implementation(npm("styled-components", "~4.4.0"))
                 implementation(npm("inline-style-prefixer", "~6.0.0"))
 
                 //ktor client js json


### PR DESCRIPTION
styled components 4.4.0 is used as newer versions break css when used with the useState react hook